### PR TITLE
Feat/add entity

### DIFF
--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/config/JpaConfig.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.npcamp.newsfeed.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/BaseEntity.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.npcamp.newsfeed.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/Follow.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/Follow.java
@@ -1,0 +1,24 @@
+package com.npcamp.newsfeed.common.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "follow")
+public class Follow extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long followerUserId;
+
+    private Long followeeUserId;
+
+    @ManyToOne
+    @JoinColumn(name = "followerUserId", insertable = false, updatable = false)
+    private User followerUser;
+
+    @ManyToOne
+    @JoinColumn(name = "followeeUserId", insertable = false, updatable = false)
+    private User followeeUser;
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/Post.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/Post.java
@@ -1,0 +1,28 @@
+package com.npcamp.newsfeed.common.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "post")
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "longtext")
+    private String content;
+
+    private Long writerId;
+
+    @ManyToOne
+    @JoinColumn(name = "writerId")
+    private User writer;
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/User.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/User.java
@@ -1,0 +1,32 @@
+package com.npcamp.newsfeed.common.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Builder
+    public User(String name, String password, String email) {
+        this.name = name;
+        this.password = password;
+        this.email = email;
+    }
+}

--- a/newsfeed/src/main/resources/application.yml
+++ b/newsfeed/src/main/resources/application.yml
@@ -1,13 +1,13 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/viva
+    url: jdbc:mysql://localhost:3306/${DB_SCHEMA}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   application:
     name: newsfeed
   config:
-    import: optional:file:.env[]
+    import: optional:file:.env[.properties]
 
   jpa:
     show-sql: true


### PR DESCRIPTION
## 이슈 번호
#1 

## 작업 내용
 - 충돌을 줄이기 위해 작업 시작 전 Entity 생성
 - BaseEntity를 JpaAuditing을 사용하여 생성일, 수정일을 관리할 수 있도록 JpaConfig파일에 세팅함.
 - BaseEntity, UserEntity, PostEntity, FollowEntity추가

## 스크린샷(선택)