### PR TITLE
feat: 회원 조회 (id) api 구현

### DIFF
--- a/newsfeed/src/main/java/com/npcamp/newsfeed/auth/dto/CreateUserRequestDto.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/auth/dto/CreateUserRequestDto.java
@@ -12,11 +12,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public class CreateUserRequestDto {
 
-    @Size(min = 1, max = 10)
+    @Size(min = 1, max = 10, message = "이름은 10자 이하로 입력해 주세요!")
     @NotBlank(message = "이름을 입력해 주세요!")
     private final String name;
 
-    @Email
+    @Email(message = "이메일 형식을 확인해 주세요!")
     @NotBlank(message = "이메일을 입력해 주세요!")
     private final String email;
 

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/auth/service/AuthServiceImpl.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/auth/service/AuthServiceImpl.java
@@ -2,14 +2,13 @@ package com.npcamp.newsfeed.auth.service;
 
 import com.npcamp.newsfeed.auth.dto.CreateUserResponseDto;
 import com.npcamp.newsfeed.common.entity.User;
+import com.npcamp.newsfeed.common.exception.ErrorCode;
 import com.npcamp.newsfeed.common.exception.ResourceConflictException;
 import com.npcamp.newsfeed.common.security.PasswordEncoder;
 import com.npcamp.newsfeed.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.npcamp.newsfeed.common.exception.ErrorCode.DUPLICATE_EMAIL;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +23,7 @@ public class AuthServiceImpl implements AuthService {
 
         // 유니크 이메일 중복 확인
         if (userRepository.existsByEmail(email)) {
-            throw new ResourceConflictException(DUPLICATE_EMAIL);
+            throw new ResourceConflictException(ErrorCode.DUPLICATE_EMAIL);
         }
 
         // 비밀번호 암호화

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/user/controller/UserController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/user/controller/UserController.java
@@ -1,0 +1,23 @@
+package com.npcamp.newsfeed.user.controller;
+
+import com.npcamp.newsfeed.auth.dto.UserResponseDto;
+import com.npcamp.newsfeed.common.payload.ApiResponse;
+import com.npcamp.newsfeed.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<UserResponseDto>> getUser(@PathVariable Long id) {
+        UserResponseDto responseDto = userService.getUser(id);
+        return new ResponseEntity<>(ApiResponse.success(responseDto), HttpStatus.OK);
+    }
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/user/dto/UserResponseDto.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/user/dto/UserResponseDto.java
@@ -1,0 +1,33 @@
+package com.npcamp.newsfeed.auth.dto;
+
+import com.npcamp.newsfeed.common.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UserResponseDto {
+
+    private final Long id;
+
+    private final String name;
+
+    private final String email;
+
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static UserResponseDto toDto(User user) {
+        return UserResponseDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/user/repository/UserRepository.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/user/repository/UserRepository.java
@@ -1,11 +1,20 @@
 package com.npcamp.newsfeed.user.repository;
 
 import com.npcamp.newsfeed.common.entity.User;
+import com.npcamp.newsfeed.common.exception.ErrorCode;
+import com.npcamp.newsfeed.common.exception.ResourceNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
+
+    default User getUserOrElseThrow(Long id) {
+        return findById(id)
+                .orElseThrow(() ->
+                        new ResourceNotFoundException(ErrorCode.USER_NOT_FOUND)
+                );
+    }
 
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/user/service/UserService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/user/service/UserService.java
@@ -1,0 +1,9 @@
+package com.npcamp.newsfeed.user.service;
+
+import com.npcamp.newsfeed.auth.dto.UserResponseDto;
+
+public interface UserService {
+
+    UserResponseDto getUser(Long id);
+
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/user/service/UserServiceImpl.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/user/service/UserServiceImpl.java
@@ -1,0 +1,21 @@
+package com.npcamp.newsfeed.user.service;
+
+import com.npcamp.newsfeed.auth.dto.UserResponseDto;
+import com.npcamp.newsfeed.common.entity.User;
+import com.npcamp.newsfeed.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService{
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserResponseDto getUser(Long id) {
+        User user = userRepository.getUserOrElseThrow(id);
+        return UserResponseDto.toDto(user);
+    }
+
+}


### PR DESCRIPTION
## 이슈 번호
#13 

## 작업 내용
- User 3계층 구현
- getUser(Long id) 유저 단건 조회 api 구현

## 스크린샷(선택)
