### PR TITLE
feat : 회원탈퇴 api 기능 구현

### DIFF
--- a/newsfeed/src/main/java/com/npcamp/newsfeed/auth/controller/AuthController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/auth/controller/AuthController.java
@@ -4,14 +4,12 @@ import com.npcamp.newsfeed.auth.service.AuthService;
 import com.npcamp.newsfeed.auth.dto.CreateUserRequestDto;
 import com.npcamp.newsfeed.auth.dto.CreateUserResponseDto;
 import com.npcamp.newsfeed.common.payload.ApiResponse;
+import com.npcamp.newsfeed.auth.dto.DeleteUserRequestDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * 회원 인증 관련 기능을 제공하는 컨트롤러 클래스.
@@ -32,5 +30,15 @@ public class AuthController {
     public ResponseEntity<ApiResponse<CreateUserResponseDto>> sighUp(@Valid @RequestBody CreateUserRequestDto requestDto) {
         CreateUserResponseDto responseDto = authService.signUp(requestDto.getName(), requestDto.getEmail(), requestDto.getPassword());
         return new ResponseEntity<>(ApiResponse.success(responseDto), HttpStatus.CREATED);
+    }
+
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteUser(
+            @PathVariable Long id,
+            @RequestBody DeleteUserRequestDto requestDto
+    ) {
+        authService.deleteUser(id, requestDto.getPassword());
+        return new ResponseEntity<>(ApiResponse.success("회원탈퇴가 완료되었습니다."), HttpStatus.OK);
     }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/auth/dto/DeleteUserRequestDto.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/auth/dto/DeleteUserRequestDto.java
@@ -1,0 +1,17 @@
+package com.npcamp.newsfeed.auth.dto;
+
+import com.npcamp.newsfeed.common.constant.RegexPattern;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteUserRequestDto {
+
+    @NotBlank(message = "비밀번호를 입력해 주세요!")
+    @Pattern(regexp = RegexPattern.PASSWORD, message = "비밀번호는 8~16자리이며, 영문, 숫자, 특수문자를 최소 1개 이상 포함해야 합니다.")
+    private final String password;
+
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/auth/service/AuthService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/auth/service/AuthService.java
@@ -5,4 +5,7 @@ import com.npcamp.newsfeed.auth.dto.CreateUserResponseDto;
 public interface AuthService {
 
     CreateUserResponseDto signUp(String name, String email, String password);
+
+    void deleteUser(Long id, String password);
+
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/auth/service/AuthServiceImpl.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/auth/service/AuthServiceImpl.java
@@ -4,6 +4,7 @@ import com.npcamp.newsfeed.auth.dto.CreateUserResponseDto;
 import com.npcamp.newsfeed.common.entity.User;
 import com.npcamp.newsfeed.common.exception.ErrorCode;
 import com.npcamp.newsfeed.common.exception.ResourceConflictException;
+import com.npcamp.newsfeed.common.exception.ResourceForbiddenException;
 import com.npcamp.newsfeed.common.security.PasswordEncoder;
 import com.npcamp.newsfeed.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,28 @@ public class AuthServiceImpl implements AuthService {
         User savedUser = userRepository.save(user);
 
         return CreateUserResponseDto.toDto(savedUser);
+    }
+
+    /**
+     * 회원탈퇴 로직
+     *
+     * @param id       사용자 id
+     * @param password 사용자 비밀번호
+     */
+    @Override
+    @Transactional
+    public void deleteUser(Long id, String password) {
+
+        // 해당 Id를 갖는 유저 조회
+        User user = userRepository.getUserOrElseThrow(id);
+
+        // 비밀번호 일치여부 확인
+        if (!encoder.matches(password, user.getPassword())) {
+            throw new ResourceForbiddenException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        // 회원탈퇴 ( deleted = false -> true / soft delete 적용 )
+        userRepository.delete(user);
     }
 
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/User.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/User.java
@@ -5,9 +5,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.apache.logging.log4j.util.Strings;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
+@SQLDelete(sql = "UPDATE user SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 @NoArgsConstructor
 public class User extends BaseEntity {
 
@@ -23,6 +27,8 @@ public class User extends BaseEntity {
 
     @Column(nullable = false)
     private String password;
+
+    private Boolean deleted = Boolean.FALSE;
 
     @Builder
     private User(String name, String password, String email) {


### PR DESCRIPTION
## 이슈 번호
#29 

## 작업 내용
- soft delete를 위한 User 엔티티에 @SQLDelete, @Where 어노테이션 적용
- User 엔티티에 논리적 삭제를 보여주기 위한 Boolean deleted 필드 추가
- deleteUser 메서드 구현

## 스크린샷(선택)
