### PR TITLE
feat: 인증된 사용자 정보를 @RequestAttribute로 처리하도록 변경

### DIFF
--- a/newsfeed/src/main/java/com/npcamp/newsfeed/auth/controller/AuthController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/auth/controller/AuthController.java
@@ -13,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import static com.npcamp.newsfeed.common.constant.RequestAttribute.USER_ID;
+
 /**
  * 회원 인증 관련 기능을 제공하는 컨트롤러 클래스.
  * - 회원 가입
@@ -34,9 +36,9 @@ public class AuthController {
     }
 
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/me")
     public ResponseEntity<ApiResponse<Void>> deleteUser(
-            @PathVariable Long id,
+            @RequestAttribute(USER_ID) Long id,
             @RequestBody DeleteUserRequestDto requestDto
     ) {
         authService.deleteUser(id, requestDto.getPassword());

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/auth/service/AuthServiceImpl.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/auth/service/AuthServiceImpl.java
@@ -54,7 +54,7 @@ public class AuthServiceImpl implements AuthService {
     public void deleteUser(Long id, String password) {
 
         // 해당 Id를 갖는 유저 조회
-        User user = userRepository.getUserOrElseThrow(id);
+        User user = userRepository.findByIdOrElseThrow(id);
 
         // 비밀번호 일치여부 확인
         if (!encoder.matches(password, user.getPassword())) {
@@ -76,7 +76,7 @@ public class AuthServiceImpl implements AuthService {
     public String login(String email, String password) {
 
         // 해당 이메일 유저 조회
-        User user = userRepository.findUserByEmailOrElseThrow(email);
+        User user = userRepository.findByEmailOrElseThrow(email);
 
         // 비밀번호 일치여부 확인
         if (!encoder.matches(password, user.getPassword())) {

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // 401 : UNAUTHORIZED Exception
     NOT_VALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."), // 필터에서 토큰 유효성 검증에 사용
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인 해주세요!"), // 로그인하지 않은 사용자가 접근 시
 
     // 403 : FORBIDDEN Exception
     INVALID_PASSWORD(HttpStatus.FORBIDDEN, "비밀번호가 일치하지 않습니다."),

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/user/controller/UserController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/user/controller/UserController.java
@@ -11,6 +11,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import static com.npcamp.newsfeed.common.constant.RequestAttribute.USER_ID;
+
 /**
  * 회원 관련 기능을 담당하는 컨트롤러 클래스.
  * - 회원 조회(id)
@@ -29,11 +31,12 @@ public class UserController {
         return new ResponseEntity<>(ApiResponse.success(responseDto), HttpStatus.OK);
     }
 
-    @PatchMapping("/{id}")
+    @PatchMapping("/me")
     public ResponseEntity<ApiResponse<UpdateUserResponseDto>> updateUser(
-            @PathVariable Long id,
+            @RequestAttribute(USER_ID) Long id,
             @RequestBody UpdateUserRequestDto requestDto
     ) {
+
         UpdateUserResponseDto responseDto =
                 userService.updateUser(
                         id,
@@ -41,12 +44,13 @@ public class UserController {
                         requestDto.getEmail(),
                         requestDto.getPassword()
                 );
+
         return new ResponseEntity<>(ApiResponse.success(responseDto), HttpStatus.OK);
     }
 
-    @PatchMapping("/{id}/password")
+    @PatchMapping("/me/password")
     public ResponseEntity<ApiResponse<Void>> updatePassword(
-            @PathVariable Long id,
+            @RequestAttribute(USER_ID) Long id,
             @RequestBody UpdatePasswordRequestDto requestDto
     ) {
         userService.updatePassword(id, requestDto.getOldPassword(), requestDto.getNewPassword());

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/user/repository/UserRepository.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/user/repository/UserRepository.java
@@ -12,17 +12,17 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
-    default User getUserOrElseThrow(Long id) {
+    default User findByIdOrElseThrow(Long id) {
         return findById(id)
                 .orElseThrow(() ->
                         new ResourceNotFoundException(ErrorCode.USER_NOT_FOUND)
                 );
     }
 
-    Optional<User> findUserByEmail(String email);
+    Optional<User> findByEmail(String email);
 
-    default User findUserByEmailOrElseThrow(String email) {
-        return findUserByEmail(email)
+    default User findByEmailOrElseThrow(String email) {
+        return findByEmail(email)
                 .orElseThrow(() ->
                         new ResourceNotFoundException(ErrorCode.USER_NOT_FOUND)
                 );

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/user/service/UserServiceImpl.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/user/service/UserServiceImpl.java
@@ -21,7 +21,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserResponseDto getUser(Long id) {
-        User user = userRepository.getUserOrElseThrow(id);
+        User user = userRepository.findByIdOrElseThrow(id);
         return UserResponseDto.toDto(user);
     }
 
@@ -41,7 +41,7 @@ public class UserServiceImpl implements UserService {
     public UpdateUserResponseDto updateUser(Long id, String name, String email, String password) {
 
         // 해당 Id를 갖는 유저 조회( 없다면 ResourceNotFoundException)
-        User user = userRepository.getUserOrElseThrow(id);
+        User user = userRepository.findByIdOrElseThrow(id);
 
         // 비밀번호 일치여부 확인
         if (!encoder.matches(password, user.getPassword())) {
@@ -70,7 +70,7 @@ public class UserServiceImpl implements UserService {
     public void updatePassword(Long id, String oldPassword, String newPassword) {
 
         // 해당 Id를 갖는 유저 조회
-        User user = userRepository.getUserOrElseThrow(id);
+        User user = userRepository.findByIdOrElseThrow(id);
 
         // 비밀번호 일치여부 확인
         if (!encoder.matches(oldPassword, user.getPassword())) {


### PR DESCRIPTION
## 이슈 번호
#41 

## 작업 내용
- 컨트롤러에서 로그인된 사용자 정보를 @RequestAttribute Long id를 통해 사용하도록 변경
- 로그인하지 않은 사용자가 회원가입,로그인을 제외한 URL에 접근할 경우, JSON 응답 메시지 반환 추가

## 스크린샷(선택)
<img width="550" alt="image" src="https://github.com/user-attachments/assets/29968d48-f419-4e66-a8aa-47f5e6adf989" />
<img width="586" alt="image" src="https://github.com/user-attachments/assets/ca5cfd27-2238-4998-b85c-2f3977b96edd" />
