### PR TITLE
feat: 댓글 조회 기능 추가

### DIFF
--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/controller/CommentController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/controller/CommentController.java
@@ -1,0 +1,26 @@
+package com.npcamp.newsfeed.comment.controller;
+
+import com.npcamp.newsfeed.comment.dto.CommentDto;
+import com.npcamp.newsfeed.comment.service.CommentService;
+import com.npcamp.newsfeed.common.payload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<CommentDto>> getComment(@PathVariable Long id) {
+        CommentDto commentDto = commentService.getComment(id);
+        return new ResponseEntity<>(ApiResponse.success(commentDto), HttpStatus.OK);
+    }
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/dto/CommentDto.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/dto/CommentDto.java
@@ -3,9 +3,11 @@ package com.npcamp.newsfeed.comment.dto;
 import com.npcamp.newsfeed.common.entity.Comment;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Getter
 @AllArgsConstructor
 @Builder
 public class CommentDto {

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/repository/CommentRepository.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/repository/CommentRepository.java
@@ -3,10 +3,14 @@ package com.npcamp.newsfeed.comment.repository;
 import com.npcamp.newsfeed.common.entity.Comment;
 import com.npcamp.newsfeed.common.exception.ErrorCode;
 import com.npcamp.newsfeed.common.exception.ResourceNotFoundException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     default Comment findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new ResourceNotFoundException(ErrorCode.COMMENT_NOT_FOUND));
     }
+
+    Page<Comment> findAllByPostId(Long postId, Pageable pageable);
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/repository/CommentRepository.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/repository/CommentRepository.java
@@ -1,7 +1,12 @@
 package com.npcamp.newsfeed.comment.repository;
 
 import com.npcamp.newsfeed.common.entity.Comment;
+import com.npcamp.newsfeed.common.exception.ErrorCode;
+import com.npcamp.newsfeed.common.exception.ResourceNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    default Comment findByIdOrElseThrow(Long id) {
+        return findById(id).orElseThrow(() -> new ResourceNotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+    }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
@@ -6,6 +6,8 @@ import com.npcamp.newsfeed.common.entity.Comment;
 import com.npcamp.newsfeed.common.entity.Post;
 import com.npcamp.newsfeed.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -32,5 +34,10 @@ public class CommentService {
     public CommentDto getComment(Long id) {
         Comment comment = commentRepository.findByIdOrElseThrow(id);
         return CommentDto.toDto(comment);
+    }
+
+    public Page<CommentDto> getCommentPage(Long postId, Pageable pageable) {
+        Page<Comment> commentPage = commentRepository.findAllByPostId(postId, pageable);
+        return commentPage.map(CommentDto::toDto);
     }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
@@ -28,4 +28,9 @@ public class CommentService {
 
         return CommentDto.toDto(saved);
     }
+
+    public CommentDto getComment(Long id) {
+        Comment comment = commentRepository.findByIdOrElseThrow(id);
+        return CommentDto.toDto(comment);
+    }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
@@ -17,10 +17,12 @@ public enum ErrorCode {
     // 404 : NOT_FOUND Exception
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시물을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
 
     // 409 : CONFLICT Exception
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
-    REUSED_PASSWORD(HttpStatus.CONFLICT, "기존 비밀번호와 동일한 비밀번호로 변경할 수 없습니다.");
+    REUSED_PASSWORD(HttpStatus.CONFLICT, "기존 비밀번호와 동일한 비밀번호로 변경할 수 없습니다.")
+    ;
 
     private final HttpStatus status;
     private final String msg;

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
@@ -77,8 +77,23 @@ public class PostController {
 
     @PostMapping("/{id}/comments")
     public ResponseEntity<ApiResponse<CommentDto>> createComment(@PathVariable(name = "id") Long postId,
-                                                        @RequestBody @Valid CreateCommentRequestDto request) {
+                                                                 @RequestBody @Valid CreateCommentRequestDto request) {
         CommentDto comment = commentService.createComment(postId, request.getContent(), request.getUserId());
         return new ResponseEntity<>(ApiResponse.success(comment), HttpStatus.CREATED);
+    }
+
+    /**
+     * 게시글 하위의 댓글 페이지 조회 기능
+     *
+     * @param postId   게시글 아이디
+     * @param pageable 페이징 정보를 담은 객체 (page = 페이지 번호, size = 한번에 가져올 양, sort = 정렬 조건, direction = 정렬 방향)
+     * @return 댓글 목록을 담은 Page<CommentDto> 객체
+     */
+    @GetMapping("/{id}/comments")
+    public ResponseEntity<ApiResponse<?>> getComments(@PathVariable(name = "id") Long postId,
+                                                      @PageableDefault(size = 10, sort = "createdAt", direction =
+                                                              Sort.Direction.DESC) Pageable pageable) {
+        Page<CommentDto> commentPage = commentService.getCommentPage(postId, pageable);
+        return new ResponseEntity<>(ApiResponse.success(commentPage), HttpStatus.OK);
     }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
@@ -75,8 +75,8 @@ public class PostController {
         return new ResponseEntity<>(ApiResponse.success(), HttpStatus.OK);
     }
 
-    @PostMapping("/{postId}/comments")
-    public ResponseEntity<ApiResponse<CommentDto>> createComment(@PathVariable(name = "postId") Long postId,
+    @PostMapping("/{id}/comments")
+    public ResponseEntity<ApiResponse<CommentDto>> createComment(@PathVariable(name = "id") Long postId,
                                                         @RequestBody @Valid CreateCommentRequestDto request) {
         CommentDto comment = commentService.createComment(postId, request.getContent(), request.getUserId());
         return new ResponseEntity<>(ApiResponse.success(comment), HttpStatus.CREATED);

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
@@ -76,7 +76,7 @@ public class PostController {
     }
 
     @PostMapping("/{postId}/comments")
-    public ResponseEntity<ApiResponse<?>> createComment(@PathVariable(name = "postId") Long postId,
+    public ResponseEntity<ApiResponse<CommentDto>> createComment(@PathVariable(name = "postId") Long postId,
                                                         @RequestBody @Valid CreateCommentRequestDto request) {
         CommentDto comment = commentService.createComment(postId, request.getContent(), request.getUserId());
         return new ResponseEntity<>(ApiResponse.success(comment), HttpStatus.CREATED);


### PR DESCRIPTION
## 이슈 번호
#43 

## 작업 내용
- 댓글 단건 조회 기능 추가
- 게시글 id를 받아 해당 게시글의 하위 댓글들을 조회하는 기능 추가
   - Page형태로 리턴하도록 구현

## 스크린샷(선택)
