### PR TITLE
feat: 댓글 수정, 삭제 기능 추가

### DIFF
--- a/newsfeed/src/main/java/com/npcamp/newsfeed/auth/controller/AuthController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/auth/controller/AuthController.java
@@ -13,7 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static com.npcamp.newsfeed.common.constant.RequestAttribute.USER_ID;
+import static com.npcamp.newsfeed.common.constant.RequestAttributeKey.USER_ID;
 
 /**
  * 회원 인증 관련 기능을 제공하는 컨트롤러 클래스.

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/controller/CommentController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/controller/CommentController.java
@@ -1,15 +1,15 @@
 package com.npcamp.newsfeed.comment.controller;
 
 import com.npcamp.newsfeed.comment.dto.CommentDto;
+import com.npcamp.newsfeed.comment.dto.UpdateCommentRequestDto;
 import com.npcamp.newsfeed.comment.service.CommentService;
+import com.npcamp.newsfeed.common.constant.RequestAttributeKey;
 import com.npcamp.newsfeed.common.payload.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/comments")
@@ -22,5 +22,13 @@ public class CommentController {
     public ResponseEntity<ApiResponse<CommentDto>> getComment(@PathVariable Long id) {
         CommentDto commentDto = commentService.getComment(id);
         return new ResponseEntity<>(ApiResponse.success(commentDto), HttpStatus.OK);
+    }
+
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<CommentDto>> updateComment(@PathVariable Long commentId,
+                                                                 @RequestBody @Valid UpdateCommentRequestDto requestDto,
+                                                                 @RequestAttribute(RequestAttributeKey.USER_ID) Long loginUserId) {
+        CommentDto saved = commentService.updateComment(commentId, requestDto.getContent(), loginUserId);
+        return new ResponseEntity<>(ApiResponse.success(saved), HttpStatus.OK);
     }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/controller/CommentController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/controller/CommentController.java
@@ -1,0 +1,26 @@
+package com.npcamp.newsfeed.comment.controller;
+
+import com.npcamp.newsfeed.comment.dto.CommentDto;
+import com.npcamp.newsfeed.comment.service.CommentService;
+import com.npcamp.newsfeed.common.payload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<CommentDto>> getComment(@PathVariable Long id) {
+        CommentDto commentDto = commentService.getComment(id);
+        return new ResponseEntity<>(ApiResponse.success(commentDto), HttpStatus.OK);
+    }
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/controller/CommentController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/controller/CommentController.java
@@ -24,11 +24,18 @@ public class CommentController {
         return new ResponseEntity<>(ApiResponse.success(commentDto), HttpStatus.OK);
     }
 
-    @PatchMapping("/{commentId}")
-    public ResponseEntity<ApiResponse<CommentDto>> updateComment(@PathVariable Long commentId,
+    @PatchMapping("/{id}")
+    public ResponseEntity<ApiResponse<CommentDto>> updateComment(@PathVariable("id") Long commentId,
                                                                  @RequestBody @Valid UpdateCommentRequestDto requestDto,
                                                                  @RequestAttribute(RequestAttributeKey.USER_ID) Long loginUserId) {
         CommentDto saved = commentService.updateComment(commentId, requestDto.getContent(), loginUserId);
         return new ResponseEntity<>(ApiResponse.success(saved), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(@PathVariable("id") Long commentId,
+                                                           @RequestAttribute(RequestAttributeKey.USER_ID) Long loginUserId) {
+        commentService.deleteComment(commentId, loginUserId);
+        return new ResponseEntity<>(ApiResponse.success("댓글을 성공적으로 삭제하였습니다."), HttpStatus.OK);
     }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/dto/CommentDto.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/dto/CommentDto.java
@@ -3,9 +3,11 @@ package com.npcamp.newsfeed.comment.dto;
 import com.npcamp.newsfeed.common.entity.Comment;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Getter
 @AllArgsConstructor
 @Builder
 public class CommentDto {

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/dto/UpdateCommentRequestDto.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/dto/UpdateCommentRequestDto.java
@@ -1,0 +1,11 @@
+package com.npcamp.newsfeed.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UpdateCommentRequestDto {
+
+    @NotBlank(message = "댓글 내용을 입력해주세요.")
+    private String content;
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/repository/CommentRepository.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/repository/CommentRepository.java
@@ -3,10 +3,14 @@ package com.npcamp.newsfeed.comment.repository;
 import com.npcamp.newsfeed.common.entity.Comment;
 import com.npcamp.newsfeed.common.exception.ErrorCode;
 import com.npcamp.newsfeed.common.exception.ResourceNotFoundException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     default Comment findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new ResourceNotFoundException(ErrorCode.COMMENT_NOT_FOUND));
     }
+
+    Page<Comment> findAllByPostId(Long postId, Pageable pageable);
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/repository/CommentRepository.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/repository/CommentRepository.java
@@ -1,7 +1,12 @@
 package com.npcamp.newsfeed.comment.repository;
 
 import com.npcamp.newsfeed.common.entity.Comment;
+import com.npcamp.newsfeed.common.exception.ErrorCode;
+import com.npcamp.newsfeed.common.exception.ResourceNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    default Comment findByIdOrElseThrow(Long id) {
+        return findById(id).orElseThrow(() -> new ResourceNotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+    }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
@@ -57,4 +57,9 @@ public class CommentService {
 
         return CommentDto.toDto(saved);
     }
+
+    public void deleteComment(Long commentId, Long loginUserId) {
+        authorValidator.validateOwner(loginUserId, commentId);
+        commentRepository.deleteById(commentId);
+    }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
@@ -46,9 +46,6 @@ public class CommentService {
     public CommentDto updateComment(Long commentId, String content, Long loginUserId) {
         Comment findComment = commentRepository.findByIdOrElseThrow(commentId);
 
-        System.out.println("loginUserId: " + loginUserId);
-        System.out.println("commentUserId: " + findComment.getId());
-
         // 작성자 검증
         authorValidator.validateOwner(findComment.getUserId(), loginUserId);
 
@@ -59,7 +56,8 @@ public class CommentService {
     }
 
     public void deleteComment(Long commentId, Long loginUserId) {
-        authorValidator.validateOwner(loginUserId, commentId);
+        Comment findComment = commentRepository.findByIdOrElseThrow(commentId);
+        authorValidator.validateOwner(findComment.getUserId(), loginUserId);
         commentRepository.deleteById(commentId);
     }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
@@ -6,6 +6,8 @@ import com.npcamp.newsfeed.common.entity.Comment;
 import com.npcamp.newsfeed.common.entity.Post;
 import com.npcamp.newsfeed.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -32,5 +34,10 @@ public class CommentService {
     public CommentDto getComment(Long id) {
         Comment comment = commentRepository.findByIdOrElseThrow(id);
         return CommentDto.toDto(comment);
+    }
+
+    public Page<CommentDto> getCommentPage(Long postId, Pageable pageable) {
+        Page<Comment> commentPage = commentRepository.findAllByPostId(postId, pageable);
+        return commentPage.map(CommentDto::toDto);
     }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
@@ -4,6 +4,7 @@ import com.npcamp.newsfeed.comment.dto.CommentDto;
 import com.npcamp.newsfeed.comment.repository.CommentRepository;
 import com.npcamp.newsfeed.common.entity.Comment;
 import com.npcamp.newsfeed.common.entity.Post;
+import com.npcamp.newsfeed.common.validator.AuthorValidator;
 import com.npcamp.newsfeed.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,6 +17,7 @@ public class CommentService {
 
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+    private final AuthorValidator authorValidator;
 
     public CommentDto createComment(Long postId, String content, Long userId) {
         Post findPost = postRepository.findByIdOrElseThrow(postId);
@@ -39,5 +41,20 @@ public class CommentService {
     public Page<CommentDto> getCommentPage(Long postId, Pageable pageable) {
         Page<Comment> commentPage = commentRepository.findAllByPostId(postId, pageable);
         return commentPage.map(CommentDto::toDto);
+    }
+
+    public CommentDto updateComment(Long commentId, String content, Long loginUserId) {
+        Comment findComment = commentRepository.findByIdOrElseThrow(commentId);
+
+        System.out.println("loginUserId: " + loginUserId);
+        System.out.println("commentUserId: " + findComment.getId());
+
+        // 작성자 검증
+        authorValidator.validateOwner(findComment.getUserId(), loginUserId);
+
+        findComment.setContent(content);
+        Comment saved = commentRepository.save(findComment);
+
+        return CommentDto.toDto(saved);
     }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
@@ -28,4 +28,9 @@ public class CommentService {
 
         return CommentDto.toDto(saved);
     }
+
+    public CommentDto getComment(Long id) {
+        Comment comment = commentRepository.findByIdOrElseThrow(id);
+        return CommentDto.toDto(comment);
+    }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/constant/RequestAttributeKey.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/constant/RequestAttributeKey.java
@@ -4,7 +4,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class RequestAttribute {
+public class RequestAttributeKey {
 
     // 토큰에서 꺼내온 Value 를 저장할 때 쓸 Key
     public static final String USER_ID = "userId";

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/Comment.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/Comment.java
@@ -33,4 +33,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "userId", insertable = false, updatable = false)
     private User user;
 
+    public void setContent(String content) {
+        this.content = content;
+    }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 
     // 403 : FORBIDDEN Exception
     INVALID_PASSWORD(HttpStatus.FORBIDDEN, "비밀번호가 일치하지 않습니다."),
+    NOT_RESOURCE_OWNER(HttpStatus.FORBIDDEN, "해당 리소스 소유자가 아닙니다."),
 
     // 404 : NOT_FOUND Exception
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
@@ -17,10 +17,12 @@ public enum ErrorCode {
     // 404 : NOT_FOUND Exception
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시물을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
 
     // 409 : CONFLICT Exception
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
-    REUSED_PASSWORD(HttpStatus.CONFLICT, "기존 비밀번호와 동일한 비밀번호로 변경할 수 없습니다.");
+    REUSED_PASSWORD(HttpStatus.CONFLICT, "기존 비밀번호와 동일한 비밀번호로 변경할 수 없습니다.")
+    ;
 
     private final HttpStatus status;
     private final String msg;

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/filter/JwtFilter.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/filter/JwtFilter.java
@@ -1,7 +1,7 @@
 package com.npcamp.newsfeed.common.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.npcamp.newsfeed.common.constant.RequestAttribute;
+import com.npcamp.newsfeed.common.constant.RequestAttributeKey;
 import com.npcamp.newsfeed.common.exception.ErrorCode;
 import com.npcamp.newsfeed.common.payload.ApiResponse;
 import com.npcamp.newsfeed.common.security.JwtUtil;
@@ -56,7 +56,7 @@ public class JwtFilter implements Filter {
 
         // 5. 토큰에서 userId 추출 후 HttpServletRequest에 저장
         Long userId = jwtUtil.extractUserId(token);
-        httpRequest.setAttribute(RequestAttribute.USER_ID, userId);
+        httpRequest.setAttribute(RequestAttributeKey.USER_ID, userId);
 
         // 6. 다음 필터로 요청 전달
         chain.doFilter(httpRequest, httpResponse);

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/validator/AuthorValidator.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/validator/AuthorValidator.java
@@ -1,0 +1,21 @@
+package com.npcamp.newsfeed.common.validator;
+
+import com.npcamp.newsfeed.common.exception.ErrorCode;
+import com.npcamp.newsfeed.common.exception.ResourceForbiddenException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthorValidator {
+    /**
+     * 현재 사용자가 리소스 작성자인지 검증
+     *
+     * @param resourceOwnerId 리소스를 작성한 사용자 ID
+     * @param currentUserId 현재 로그인한 사용자 ID
+     * @throws ResourceForbiddenException 작성자가 아닌 경우 NOT_RESOURCE_OWNER 코드가 담김 에러 리턴
+     */
+    public void validateOwner(Long resourceOwnerId, Long currentUserId) {
+        if (!resourceOwnerId.equals(currentUserId)) {
+            throw new ResourceForbiddenException(ErrorCode.NOT_RESOURCE_OWNER);
+        }
+    }
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
@@ -77,8 +77,23 @@ public class PostController {
 
     @PostMapping("/{id}/comments")
     public ResponseEntity<ApiResponse<CommentDto>> createComment(@PathVariable(name = "id") Long postId,
-                                                        @RequestBody @Valid CreateCommentRequestDto request) {
+                                                                 @RequestBody @Valid CreateCommentRequestDto request) {
         CommentDto comment = commentService.createComment(postId, request.getContent(), request.getUserId());
         return new ResponseEntity<>(ApiResponse.success(comment), HttpStatus.CREATED);
+    }
+
+    /**
+     * 게시글 하위의 댓글 페이지 조회 기능
+     *
+     * @param postId   게시글 아이디
+     * @param pageable 페이징 정보를 담은 객체 (page = 페이지 번호, size = 한번에 가져올 양, sort = 정렬 조건, direction = 정렬 방향)
+     * @return 댓글 목록을 담은 Page<CommentDto> 객체
+     */
+    @GetMapping("/{id}/comments")
+    public ResponseEntity<ApiResponse<?>> getComments(@PathVariable(name = "id") Long postId,
+                                                      @PageableDefault(size = 10, sort = "createdAt", direction =
+                                                              Sort.Direction.DESC) Pageable pageable) {
+        Page<CommentDto> commentPage = commentService.getCommentPage(postId, pageable);
+        return new ResponseEntity<>(ApiResponse.success(commentPage), HttpStatus.OK);
     }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
@@ -75,8 +75,8 @@ public class PostController {
         return new ResponseEntity<>(ApiResponse.success(), HttpStatus.OK);
     }
 
-    @PostMapping("/{postId}/comments")
-    public ResponseEntity<ApiResponse<CommentDto>> createComment(@PathVariable(name = "postId") Long postId,
+    @PostMapping("/{id}/comments")
+    public ResponseEntity<ApiResponse<CommentDto>> createComment(@PathVariable(name = "id") Long postId,
                                                         @RequestBody @Valid CreateCommentRequestDto request) {
         CommentDto comment = commentService.createComment(postId, request.getContent(), request.getUserId());
         return new ResponseEntity<>(ApiResponse.success(comment), HttpStatus.CREATED);

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
@@ -76,7 +76,7 @@ public class PostController {
     }
 
     @PostMapping("/{postId}/comments")
-    public ResponseEntity<ApiResponse<?>> createComment(@PathVariable(name = "postId") Long postId,
+    public ResponseEntity<ApiResponse<CommentDto>> createComment(@PathVariable(name = "postId") Long postId,
                                                         @RequestBody @Valid CreateCommentRequestDto request) {
         CommentDto comment = commentService.createComment(postId, request.getContent(), request.getUserId());
         return new ResponseEntity<>(ApiResponse.success(comment), HttpStatus.CREATED);

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/user/controller/UserController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/user/controller/UserController.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static com.npcamp.newsfeed.common.constant.RequestAttribute.USER_ID;
+import static com.npcamp.newsfeed.common.constant.RequestAttributeKey.USER_ID;
 
 /**
  * 회원 관련 기능을 담당하는 컨트롤러 클래스.


### PR DESCRIPTION
## 이슈 번호
#45 

## 작업 내용
- 원활한 참조 및 명확한 의미 전달을 위해 RequestAttribute key를 관리하던 RequestAttribute 클래스 이름을 변경
   - RequestAttribute -> RequestAttributeKey 로 변경
- 게시글의 작성자인지 등을 검증하는 리소스 소유자 검증 로직이 다른 곳에서도 계속 사용될 것으로 판단되어 소유자 검증 로직이 구현된 클래스를 컴포넌트로 등록하여 빈으로 관리하도록 구현
- 댓글 수정 기능 추가
- 댓글 삭제 기능 추가

**댓글 조회 기능 PR이 닫히기 전에 추가한 커밋들 입니다. 댓글 조회 기능 PR을 먼저 확인해주세요.

## 스크린샷(선택)
