### PR TITLE
feat:jwt인증 로직 Post Controller, Post Service에 추가, 에러코드 추가

### DIFF
--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/PostLike.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/PostLike.java
@@ -16,14 +16,13 @@ public class PostLike {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     public Long postLikeId;
 
-    @Column(name = "postId", nullable = false)
+
     private Long postId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "postId", insertable = false, unique = false)
+    @JoinColumn(name = "postId", insertable = false, updatable = false)
     public Post post;
 
-    @Column(name = "userId", nullable = false)
     public Long userId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/PostLike.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/entity/PostLike.java
@@ -1,0 +1,32 @@
+package com.npcamp.newsfeed.common.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "post_like")
+
+public class PostLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long postLikeId;
+
+    @Column(name = "postId", nullable = false)
+    private Long postId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "postId", insertable = false, unique = false)
+    public Post post;
+
+    @Column(name = "userId", nullable = false)
+    public Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", insertable = false, updatable = false)
+    public User user;
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     // 403 : FORBIDDEN Exception
     INVALID_PASSWORD(HttpStatus.FORBIDDEN, "비밀번호가 일치하지 않습니다."),
     NOT_RESOURCE_OWNER(HttpStatus.FORBIDDEN, "해당 리소스 소유자가 아닙니다."),
+    CANNOT_LIKE_OWN_POST(HttpStatus.FORBIDDEN, "본인의 게시물에는 좋아요를 남길 수 없습니다."),
 
     // 404 : NOT_FOUND Exception
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
 
     // 403 : FORBIDDEN Exception
     INVALID_PASSWORD(HttpStatus.FORBIDDEN, "비밀번호가 일치하지 않습니다."),
+    UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "해당 게시물을 수정·삭제할 권한이 없습니다."),  // 새로 추가
+
 
     // 404 : NOT_FOUND Exception
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
 
     // 403 : FORBIDDEN Exception
     INVALID_PASSWORD(HttpStatus.FORBIDDEN, "비밀번호가 일치하지 않습니다."),
-    UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "해당 게시물을 수정·삭제할 권한이 없습니다."),  // 새로 추가
+    UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "해당 게시물을 수정·삭제할 권한이 없습니다."),
+    CANNOT_LIKE_OWN_POST(HttpStatus.FORBIDDEN, "본인의 게시물에는 좋아요를 남길 수 없습니다."),// 새로 추가
 
 
     // 404 : NOT_FOUND Exception

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
@@ -9,7 +9,6 @@ import com.npcamp.newsfeed.post.dto.PostResponseDto;
 import com.npcamp.newsfeed.post.service.PostService;
 
 import jakarta.validation.Valid;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
@@ -100,4 +100,14 @@ public class PostController {
         Page<CommentDto> commentPage = commentService.getCommentPage(postId, pageable);
         return new ResponseEntity<>(ApiResponse.success(commentPage), HttpStatus.OK);
     }
+
+    @PostMapping("/{id}/like")
+    public ResponseEntity<ApiResponse<Void>> toggleLike(@PathVariable Long id,
+                                                        @RequestAttribute(name = com.npcamp.newsfeed.common.constant.RequestAttribute.USER_ID) Long userId) {
+        boolean isNowLiked = postService.toggleLike(id, userId);
+        String message = isNowLiked ? "좋아요를 등록했습니다." : "좋아요를 취소했습니다.";
+        return new ResponseEntity<>(ApiResponse.success(message), HttpStatus.OK);
+    }
+
+
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
@@ -3,6 +3,7 @@ package com.npcamp.newsfeed.post.controller;
 import com.npcamp.newsfeed.comment.dto.CommentDto;
 import com.npcamp.newsfeed.comment.dto.CreateCommentRequestDto;
 import com.npcamp.newsfeed.comment.service.CommentService;
+import com.npcamp.newsfeed.common.constant.RequestAttributeKey;
 import com.npcamp.newsfeed.common.payload.ApiResponse;
 import com.npcamp.newsfeed.post.dto.PostRequestDto;
 import com.npcamp.newsfeed.post.dto.PostResponseDto;
@@ -34,7 +35,7 @@ public class PostController {
      */
     @PostMapping
     public ResponseEntity<ApiResponse<PostResponseDto>> createPost(@RequestBody @Valid PostRequestDto requestDto,
-                                                                   @RequestAttribute(name = com.npcamp.newsfeed.common.constant.RequestAttribute.USER_ID) Long userId ) {
+                                                                   @RequestAttribute(name = RequestAttributeKey.USER_ID) Long userId ) {
         PostResponseDto responseDto = postService.createPost(userId, requestDto);
         return new ResponseEntity<>(ApiResponse.success(responseDto), HttpStatus.CREATED);
     }
@@ -64,7 +65,7 @@ public class PostController {
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponse<PostResponseDto>> updatePost(@PathVariable Long id,
                                                                    @RequestBody @Valid PostRequestDto requestDto,
-                                                                   @RequestAttribute(name = com.npcamp.newsfeed.common.constant.RequestAttribute.USER_ID)  Long userId) {
+                                                                   @RequestAttribute(name = RequestAttributeKey.USER_ID)  Long userId) {
         PostResponseDto updated = postService.updatePost(id, userId, requestDto);
         return new ResponseEntity<>(ApiResponse.success(updated), HttpStatus.OK);
     }
@@ -74,7 +75,7 @@ public class PostController {
      */
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> deletePost( @PathVariable Long id,
-                                                         @RequestAttribute(name = com.npcamp.newsfeed.common.constant.RequestAttribute.USER_ID) Long userId) {
+                                                         @RequestAttribute(name = RequestAttributeKey.USER_ID) Long userId) {
         postService.deletePost(id, userId);
         return new ResponseEntity<>(ApiResponse.success(), HttpStatus.OK);
     }
@@ -103,7 +104,7 @@ public class PostController {
 
     @PostMapping("/{id}/like")
     public ResponseEntity<ApiResponse<Void>> toggleLike(@PathVariable Long id,
-                                                        @RequestAttribute(name = com.npcamp.newsfeed.common.constant.RequestAttribute.USER_ID) Long userId) {
+                                                        @RequestAttribute(name = RequestAttributeKey.USER_ID) Long userId) {
         boolean isNowLiked = postService.toggleLike(id, userId);
         String message = isNowLiked ? "좋아요를 등록했습니다." : "좋아요를 취소했습니다.";
         return new ResponseEntity<>(ApiResponse.success(message), HttpStatus.OK);

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
@@ -7,7 +7,7 @@ import com.npcamp.newsfeed.common.payload.ApiResponse;
 import com.npcamp.newsfeed.post.dto.PostRequestDto;
 import com.npcamp.newsfeed.post.dto.PostResponseDto;
 import com.npcamp.newsfeed.post.service.PostService;
-import com.npcamp.newsfeed.common.constant.RequestAttribute;
+
 import jakarta.validation.Valid;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +18,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestAttribute;
+
 
 
 @RestController
@@ -32,8 +34,8 @@ public class PostController {
      * 생성
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<PostResponseDto>> createPost(@RequestBody @Valid PostRequestDto requestDto, HttpServletRequest request) {
-        Long userId = (Long) request.getAttribute(RequestAttribute.USER_ID);
+    public ResponseEntity<ApiResponse<PostResponseDto>> createPost(@RequestBody @Valid PostRequestDto requestDto,
+                                                                   @RequestAttribute(name = com.npcamp.newsfeed.common.constant.RequestAttribute.USER_ID) Long userId ) {
         PostResponseDto responseDto = postService.createPost(userId, requestDto);
         return new ResponseEntity<>(ApiResponse.success(responseDto), HttpStatus.CREATED);
     }
@@ -61,8 +63,9 @@ public class PostController {
      * 수정
      */
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<PostResponseDto>> updatePost(@PathVariable Long id, @RequestBody @Valid PostRequestDto requestDto, HttpServletRequest request) {
-        Long userId = (Long) request.getAttribute(RequestAttribute.USER_ID);
+    public ResponseEntity<ApiResponse<PostResponseDto>> updatePost(@PathVariable Long id,
+                                                                   @RequestBody @Valid PostRequestDto requestDto,
+                                                                   @RequestAttribute(name = com.npcamp.newsfeed.common.constant.RequestAttribute.USER_ID)  Long userId) {
         PostResponseDto updated = postService.updatePost(id, userId, requestDto);
         return new ResponseEntity<>(ApiResponse.success(updated), HttpStatus.OK);
     }
@@ -71,8 +74,8 @@ public class PostController {
      * 삭제
      */
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long id, HttpServletRequest request) {
-        Long userId = (Long) request.getAttribute(RequestAttribute.USER_ID);
+    public ResponseEntity<ApiResponse<Void>> deletePost( @PathVariable Long id,
+                                                         @RequestAttribute(name = com.npcamp.newsfeed.common.constant.RequestAttribute.USER_ID) Long userId) {
         postService.deletePost(id, userId);
         return new ResponseEntity<>(ApiResponse.success(), HttpStatus.OK);
     }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
@@ -7,7 +7,9 @@ import com.npcamp.newsfeed.common.payload.ApiResponse;
 import com.npcamp.newsfeed.post.dto.PostRequestDto;
 import com.npcamp.newsfeed.post.dto.PostResponseDto;
 import com.npcamp.newsfeed.post.service.PostService;
+import com.npcamp.newsfeed.common.constant.RequestAttribute;
 import jakarta.validation.Valid;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -30,9 +32,10 @@ public class PostController {
      * 생성
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<PostResponseDto>> createPost(@RequestBody @Valid PostRequestDto req) {
-        PostResponseDto dto = postService.createPost(req.getTitle(), req.getContent(), req.getWriterId());
-        return new ResponseEntity<>(ApiResponse.success(dto), HttpStatus.CREATED);
+    public ResponseEntity<ApiResponse<PostResponseDto>> createPost(@RequestBody @Valid PostRequestDto requestDto, HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute(RequestAttribute.USER_ID);
+        PostResponseDto responseDto = postService.createPost(userId, requestDto);
+        return new ResponseEntity<>(ApiResponse.success(responseDto), HttpStatus.CREATED);
     }
 
     /**
@@ -58,10 +61,9 @@ public class PostController {
      * 수정
      */
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<PostResponseDto>> updatePost(@PathVariable Long id,
-                                                                   @RequestBody @Valid PostRequestDto req) {
-        PostResponseDto updated = postService.updatePost(id, req.getTitle(), req.getContent());
-
+    public ResponseEntity<ApiResponse<PostResponseDto>> updatePost(@PathVariable Long id, @RequestBody @Valid PostRequestDto requestDto, HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute(RequestAttribute.USER_ID);
+        PostResponseDto updated = postService.updatePost(id, userId, requestDto);
         return new ResponseEntity<>(ApiResponse.success(updated), HttpStatus.OK);
     }
 
@@ -69,9 +71,9 @@ public class PostController {
      * 삭제
      */
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long id) {
-        postService.deletePost(id);
-
+    public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long id, HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute(RequestAttribute.USER_ID);
+        postService.deletePost(id, userId);
         return new ResponseEntity<>(ApiResponse.success(), HttpStatus.OK);
     }
 

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/dto/PostRequestDto.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/dto/PostRequestDto.java
@@ -1,7 +1,6 @@
 package com.npcamp.newsfeed.post.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,7 +12,4 @@ public class PostRequestDto {
 
     @NotBlank(message = "내용을 입력해주세요.")
     private String content;
-
-    @NotNull(message = "작성자 ID를 입력해주세요.")
-    private Long writerId;
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/repository/PostLikeRepository.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/repository/PostLikeRepository.java
@@ -1,0 +1,12 @@
+package com.npcamp.newsfeed.post.repository;
+
+import com.npcamp.newsfeed.common.entity.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    // 해당 userId, postId 조합이 이미 존재하는지 확인
+    boolean existsByUserIdAndPostId(Long userId, Long postId);
+
+    // 좋아요 취소를 위해 물리 삭제
+    void deleteByUserIdAndPostId(Long userId, Long postId);
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/service/PostService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/service/PostService.java
@@ -3,6 +3,7 @@ package com.npcamp.newsfeed.post.service;
 import com.npcamp.newsfeed.common.entity.Post;
 import com.npcamp.newsfeed.common.entity.PostLike;
 import com.npcamp.newsfeed.common.exception.*;
+import com.npcamp.newsfeed.common.validator.AuthorValidator;
 import com.npcamp.newsfeed.post.dto.PostRequestDto;
 import com.npcamp.newsfeed.post.dto.PostResponseDto;
 import com.npcamp.newsfeed.post.repository.PostLikeRepository;
@@ -20,7 +21,7 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final PostLikeRepository postLikeRepository;
-
+    private final AuthorValidator authorValidator;
 
     /**
      * CREATE: 새 게시글을 저장하고 DTO로 반환한다.
@@ -54,9 +55,7 @@ public class PostService {
     public PostResponseDto updatePost(Long postId, Long userId, PostRequestDto requestDto) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new ResourceNotFoundException(ErrorCode.POST_NOT_FOUND));
 
-        if (!post.getWriterId().equals(userId)) {
-            throw new ResourceForbiddenException(ErrorCode.UNAUTHORIZED_USER);
-        }
+        authorValidator.validateOwner(post.getWriterId(), userId);
 
         post.setTitle(requestDto.getTitle());
         post.setContent(requestDto.getContent());
@@ -72,8 +71,7 @@ public class PostService {
     public void deletePost(Long postId, Long userId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new ResourceNotFoundException(ErrorCode.POST_NOT_FOUND));
 
-        if (!post.getWriterId().equals(userId)) {
-            throw new ResourceForbiddenException(ErrorCode.UNAUTHORIZED_USER);        }
+        authorValidator.validateOwner(post.getWriterId(), userId);
 
         postRepository.delete(post);
     }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/service/PostService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/service/PostService.java
@@ -54,9 +54,6 @@ public class PostService {
 
         post.setTitle(requestDto.getTitle());
         post.setContent(requestDto.getContent());
-/*
-        setUpdatedAt 는 japAuditing에서 자동으로 되는걸로 알고 추가하지 않았습니다.
-*/
 
         Post updated = postRepository.save(post);
         return PostResponseDto.toDto(updated);


### PR DESCRIPTION
## 이슈 번호 47

## 작업 내용

-  게시물 생성시 jwt에서 받은 userId를 writerId로 지정
-  writerId 와 userId를 비교, 불일치시 ForbiddenException
- setUpdatedAt 는 japAuditing에서 자동으로 되니까 삭제
- UNAUTHORIZED_USER 상수, ForbiddenException에 추가 

## 스크린샷(선택)
