### PR TITLE
refactor: Comment 관련 기능 리팩토링

### DIFF
--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/dto/CreateCommentRequestDto.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/dto/CreateCommentRequestDto.java
@@ -9,7 +9,4 @@ public class CreateCommentRequestDto {
     @NotBlank(message = "댓글 내용을 입력해주세요.")
     private String content;
 
-    // TODO : JWT 사용한 인증 로직 적용 후 삭제
-    private Long userId;
-
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
@@ -21,14 +21,10 @@ public class CommentService {
     private final AuthorValidator authorValidator;
 
     @Transactional
-    public CommentDto createComment(Long postId, String content, Long userId) {
+    public CommentDto createComment(Long postId, String content, Long loginUserId) {
         Post findPost = postRepository.findByIdOrElseThrow(postId);
 
-        Comment comment = Comment.builder()
-                .postId(findPost.getId())
-                .content(content)
-                .userId(userId)
-                .build();
+        Comment comment = Comment.builder().postId(findPost.getId()).content(content).userId(loginUserId).build();
 
         Comment saved = commentRepository.save(comment);
 

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/comment/service/CommentService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +20,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final AuthorValidator authorValidator;
 
+    @Transactional
     public CommentDto createComment(Long postId, String content, Long userId) {
         Post findPost = postRepository.findByIdOrElseThrow(postId);
 
@@ -33,16 +35,19 @@ public class CommentService {
         return CommentDto.toDto(saved);
     }
 
+    @Transactional(readOnly = true)
     public CommentDto getComment(Long id) {
         Comment comment = commentRepository.findByIdOrElseThrow(id);
         return CommentDto.toDto(comment);
     }
 
+    @Transactional(readOnly = true)
     public Page<CommentDto> getCommentPage(Long postId, Pageable pageable) {
         Page<Comment> commentPage = commentRepository.findAllByPostId(postId, pageable);
         return commentPage.map(CommentDto::toDto);
     }
 
+    @Transactional
     public CommentDto updateComment(Long commentId, String content, Long loginUserId) {
         Comment findComment = commentRepository.findByIdOrElseThrow(commentId);
 
@@ -55,6 +60,7 @@ public class CommentService {
         return CommentDto.toDto(saved);
     }
 
+    @Transactional
     public void deleteComment(Long commentId, Long loginUserId) {
         Comment findComment = commentRepository.findByIdOrElseThrow(commentId);
         authorValidator.validateOwner(findComment.getUserId(), loginUserId);

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
@@ -95,7 +95,7 @@ public class PostController {
      * @return 댓글 목록을 담은 Page<CommentDto> 객체
      */
     @GetMapping("/{id}/comments")
-    public ResponseEntity<ApiResponse<?>> getComments(@PathVariable(name = "id") Long postId, @PageableDefault(size =
+    public ResponseEntity<ApiResponse<Page<CommentDto>>> getComments(@PathVariable(name = "id") Long postId, @PageableDefault(size =
             10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         Page<CommentDto> commentPage = commentService.getCommentPage(postId, pageable);
         return new ResponseEntity<>(ApiResponse.success(commentPage), HttpStatus.OK);

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/post/controller/PostController.java
@@ -62,8 +62,7 @@ public class PostController {
      */
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponse<PostResponseDto>> updatePost(@PathVariable(name = "id") Long postId,
-                                                                   @RequestAttribute(RequestAttributeKey.USER_ID) Long userId,
-                                                                   @RequestBody @Valid UpdatePostRequestDto req) {
+                                                                   @RequestAttribute(RequestAttributeKey.USER_ID) Long userId, @RequestBody @Valid UpdatePostRequestDto req) {
         PostResponseDto updated = postService.updatePost(postId, userId, req.getTitle(), req.getContent());
 
         return new ResponseEntity<>(ApiResponse.success(updated), HttpStatus.OK);
@@ -82,8 +81,9 @@ public class PostController {
 
     @PostMapping("/{id}/comments")
     public ResponseEntity<ApiResponse<CommentDto>> createComment(@PathVariable(name = "id") Long postId,
-                                                                 @RequestBody @Valid CreateCommentRequestDto request) {
-        CommentDto comment = commentService.createComment(postId, request.getContent(), request.getUserId());
+                                                                 @RequestBody @Valid CreateCommentRequestDto request,
+                                                                 @RequestAttribute(RequestAttributeKey.USER_ID) Long loginUserId) {
+        CommentDto comment = commentService.createComment(postId, request.getContent(), loginUserId);
         return new ResponseEntity<>(ApiResponse.success(comment), HttpStatus.CREATED);
     }
 
@@ -95,9 +95,8 @@ public class PostController {
      * @return 댓글 목록을 담은 Page<CommentDto> 객체
      */
     @GetMapping("/{id}/comments")
-    public ResponseEntity<ApiResponse<?>> getComments(@PathVariable(name = "id") Long postId,
-                                                      @PageableDefault(size = 10, sort = "createdAt", direction =
-                                                              Sort.Direction.DESC) Pageable pageable) {
+    public ResponseEntity<ApiResponse<?>> getComments(@PathVariable(name = "id") Long postId, @PageableDefault(size =
+            10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         Page<CommentDto> commentPage = commentService.getCommentPage(postId, pageable);
         return new ResponseEntity<>(ApiResponse.success(commentPage), HttpStatus.OK);
     }


### PR DESCRIPTION
## 이슈 번호
#55

## 작업 내용
- CommentService의 모든 메소드에 @Transactional추가
- PostController의 CreateComment 메소드 부분을 @RequestAttribute로 로그인유저 아이디 가져와 매개변수로 넘겨주는 로직으로 변경
- PostController의 getComments 메소드의 리턴값 명시

## 스크린샷(선택)
