### PR TITLE
refactor: UserController & UserService 리팩토링

### DIFF
--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/validator/PasswordValidator.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/validator/PasswordValidator.java
@@ -1,0 +1,33 @@
+package com.npcamp.newsfeed.common.validator;
+
+import com.npcamp.newsfeed.common.exception.ErrorCode;
+import com.npcamp.newsfeed.common.exception.ResourceConflictException;
+import com.npcamp.newsfeed.common.exception.ResourceForbiddenException;
+import com.npcamp.newsfeed.common.security.PasswordEncoder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PasswordValidator {
+    private final PasswordEncoder encoder;
+
+    /**
+     * 입력받은 비밀번호와 기존의 비밀번호의 일치여부에 따른 예외 처리
+     *
+     * @param inputPassword 입력받은 비밀번호
+     * @param originalPassword 기존의 비밀번호
+     */
+    public void verifyMatch(String inputPassword, String originalPassword) {
+        if (!encoder.matches(inputPassword, originalPassword)) {
+            throw new ResourceForbiddenException(ErrorCode.INVALID_PASSWORD);
+        }
+    }
+
+    public void verifyNotSame(String inputPassword, String originalPassword) {
+        if (inputPassword.equals(originalPassword)) {
+            throw new ResourceConflictException(ErrorCode.REUSED_PASSWORD);
+        }
+    }
+
+}

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/user/controller/UserController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.npcamp.newsfeed.user.controller;
 
+import com.npcamp.newsfeed.common.constant.RequestAttributeKey;
 import com.npcamp.newsfeed.common.payload.ApiResponse;
 import com.npcamp.newsfeed.user.dto.UpdatePasswordRequestDto;
 import com.npcamp.newsfeed.user.dto.UpdateUserRequestDto;
@@ -11,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import static com.npcamp.newsfeed.common.constant.RequestAttributeKey.USER_ID;
 
 /**
  * 회원 관련 기능을 담당하는 컨트롤러 클래스.
@@ -33,27 +32,22 @@ public class UserController {
     }
 
     @PatchMapping("/me")
-    public ResponseEntity<ApiResponse<UpdateUserResponseDto>> updateUser(
-            @RequestAttribute(USER_ID) Long id,
-            @Valid @RequestBody UpdateUserRequestDto requestDto
-    ) {
+    public ResponseEntity<ApiResponse<UpdateUserResponseDto>> updateUser(@RequestAttribute(RequestAttributeKey.USER_ID) Long loginUserId,
+                                                                         @Valid @RequestBody UpdateUserRequestDto requestDto) {
 
-        UpdateUserResponseDto responseDto =
-                userService.updateUser(
-                        id,
-                        requestDto.getName(),
-                        requestDto.getEmail(),
-                        requestDto.getPassword()
-                );
+        UpdateUserResponseDto responseDto = userService.updateUser(
+                loginUserId,
+                requestDto.getName(),
+                requestDto.getEmail(),
+                requestDto.getPassword()
+        );
 
         return new ResponseEntity<>(ApiResponse.success(responseDto), HttpStatus.OK);
     }
 
     @PatchMapping("/me/password")
-    public ResponseEntity<ApiResponse<Void>> updatePassword(
-            @RequestAttribute(USER_ID) Long id,
-            @Valid @RequestBody UpdatePasswordRequestDto requestDto
-    ) {
+    public ResponseEntity<ApiResponse<Void>> updatePassword(@RequestAttribute(RequestAttributeKey.USER_ID) Long id,
+                                                            @Valid @RequestBody UpdatePasswordRequestDto requestDto) {
         userService.updatePassword(id, requestDto.getOldPassword(), requestDto.getNewPassword());
         return new ResponseEntity<>(ApiResponse.success("비밀번호 변경이 완료되었습니다."), HttpStatus.OK);
     }


### PR DESCRIPTION
## 이슈 번호
#57

## 작업 내용
- 비밀번호 일치 여부를 확인하는 메소드를 PasswordValidator 클래스로 분리
- 코드만 표시되어있던 USER_ID -> 클래스명도 보이도록 RequestAttributeKey.USER_ID 로 수정
- getUser 메소드에 @Transactional(readOnly = true) 추가
- userRepository.save 메소드 호출하여 저장 과정을 명시하도록 수정
- updateUser시 이름만 바뀌고 이메일은 바뀌지 않은 경우에도 예외가 발생하는 부분 검증 로직 변경

## 스크린샷(선택)
