### PR TITLE
feat: 팔로우 삭제 기능 구현

### DIFF
--- a/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/common/exception/ErrorCode.java
@@ -15,11 +15,13 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.FORBIDDEN, "비밀번호가 일치하지 않습니다."),
     NOT_RESOURCE_OWNER(HttpStatus.FORBIDDEN, "해당 리소스 소유자가 아닙니다."),
     CANNOT_LIKE_OWN_POST(HttpStatus.FORBIDDEN, "본인의 게시물에는 좋아요를 남길 수 없습니다."),
+    FORBIDDEN_FOLLOW_DELETE(HttpStatus.FORBIDDEN, "팔로우 삭제 권한이 없습니다."),
 
     // 404 : NOT_FOUND Exception
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시물을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
+    FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 팔로우를 찾을 수 없습니다."),
 
     // 409 : CONFLICT Exception
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/follow/controller/FollowController.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/follow/controller/FollowController.java
@@ -1,5 +1,6 @@
 package com.npcamp.newsfeed.follow.controller;
 
+import com.npcamp.newsfeed.common.constant.RequestAttributeKey;
 import com.npcamp.newsfeed.common.payload.ApiResponse;
 import com.npcamp.newsfeed.follow.dto.FollowResponseDto;
 import jakarta.validation.Valid;
@@ -41,5 +42,15 @@ public class FollowController {
     public ResponseEntity<ApiResponse<List<FollowResponseDto>>> getFollowers(@PathVariable Long followeeId) {
         List<FollowResponseDto> followers = followService.getFolloweesByFollower(followeeId);
         return ResponseEntity.ok(ApiResponse.success(followers));
+    }
+
+    // 팔로우 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteFollow(
+            @PathVariable Long id,
+            @RequestAttribute(RequestAttributeKey.USER_ID) Long loginUserId) {
+
+        followService.deleteFollow(id, loginUserId);
+        return new ResponseEntity<>(ApiResponse.success(null), HttpStatus.NO_CONTENT);
     }
 }

--- a/newsfeed/src/main/java/com/npcamp/newsfeed/follow/service/FollowService.java
+++ b/newsfeed/src/main/java/com/npcamp/newsfeed/follow/service/FollowService.java
@@ -1,6 +1,8 @@
 package com.npcamp.newsfeed.follow.service;
 
 import com.npcamp.newsfeed.common.entity.Follow;
+import com.npcamp.newsfeed.common.exception.ErrorCode;
+import com.npcamp.newsfeed.common.exception.ResourceNotFoundException;
 import com.npcamp.newsfeed.follow.dto.FollowResponseDto;
 import com.npcamp.newsfeed.follow.repository.FollowRepository;
 import lombok.RequiredArgsConstructor;
@@ -47,5 +49,18 @@ public class FollowService {
         return follows.stream()
                 .map(FollowResponseDto::toDto)
                 .collect(Collectors.toList());
+    }
+
+    // 팔로우 삭제
+    @Transactional
+    public void deleteFollow(Long id, Long loginUserId) {
+        Follow follow = followRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(ErrorCode.FOLLOW_NOT_FOUND));
+
+        if (!follow.getFollowerUserId().equals(loginUserId)) {
+            throw new ResourceNotFoundException(ErrorCode.FORBIDDEN_FOLLOW_DELETE);
+        }
+
+        followRepository.delete(follow);
     }
 }


### PR DESCRIPTION
## 이슈 번호
#49

## 작업 내용
- [x] 특정 팔로우 관계를 삭제하는 API 구현
- [x] 로그인한 사용자 본인이 생성한 팔로우 관계만 삭제 가능하도록 권한 지정

## 스크린샷(선택)
